### PR TITLE
Display hotfix version

### DIFF
--- a/frontend/src/components/ComponentsTree/presenter.jsx
+++ b/frontend/src/components/ComponentsTree/presenter.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import {Spinner, Tree} from "@blueprintjs/core";
-import {getSecondaryLabel} from "../common";
+import { Spinner, Tree } from "@blueprintjs/core";
+import { getSecondaryLabel } from "../common";
+import { groupHotfixVersions } from "../../utils/version";
 
 const treeLevel = {
     ROOT: 'ROOT',
@@ -92,26 +93,7 @@ function renderComponentVersions(componentId, minorVersionId, versions, props) {
         return showRc || version.status !== 'RC'
     }).map(version => renderComponentVersion(componentId, minorVersionId, version, currentArtifacts))
 
-    const regularVersions = filteredVersions.filter(version => !version.hotfix)
-    const hotfixVersions = filteredVersions.filter(version => version.hotfix)
-
-    hotfixVersions.forEach(hotfixVersion => {
-        const parentVersion = regularVersions.find(version =>
-            hotfixVersion.version.startsWith(version.version + '-') ||
-            hotfixVersion.version.startsWith(version.version + '.')
-        )
-        if (!parentVersion) {
-            console.warn(`Parent version not found for hotfix version ${hotfixVersion.version}`)
-            return
-        }
-        if (!parentVersion.childNodes) {
-            parentVersion.childNodes = []
-            parentVersion.isExpanded = true
-        }
-        parentVersion.childNodes.push(hotfixVersion)
-    })
-
-    return regularVersions
+    return groupHotfixVersions(filteredVersions)
 }
 
 function renderComponentVersion(componentId, minorVersionId, version, currentArtifacts) {

--- a/frontend/src/components/ComponentsTree/presenter.jsx
+++ b/frontend/src/components/ComponentsTree/presenter.jsx
@@ -101,7 +101,7 @@ function renderComponentVersions(componentId, minorVersionId, versions, props) {
             hotfixVersion.version.startsWith(version.version + '.')
         )
         if (!parentVersion) {
-            console.log(`Parent version not found for hotfix version ${hotfixVersion.version}`)
+            console.warn(`Parent version not found for hotfix version ${hotfixVersion.version}`)
             return
         }
         if (!parentVersion.childNodes) {

--- a/frontend/src/components/ComponentsTree/presenter.jsx
+++ b/frontend/src/components/ComponentsTree/presenter.jsx
@@ -96,8 +96,14 @@ function renderComponentVersions(componentId, minorVersionId, versions, props) {
     const hotfixVersions = filteredVersions.filter(version => version.hotfix)
 
     hotfixVersions.forEach(hotfixVersion => {
-        const parentVersion = regularVersions.find(version => hotfixVersion.version.startsWith(version.version))
-        if (!parentVersion) return
+        const parentVersion = regularVersions.find(version =>
+            hotfixVersion.version.startsWith(version.version + '-') ||
+            hotfixVersion.version.startsWith(version.version + '.')
+        )
+        if (!parentVersion) {
+            console.log(`Parent version not found for hotfix version ${hotfixVersion.version}`)
+            return
+        }
         if (!parentVersion.childNodes) {
             parentVersion.childNodes = []
             parentVersion.isExpanded = true

--- a/frontend/src/components/ComponentsTree/presenter.jsx
+++ b/frontend/src/components/ComponentsTree/presenter.jsx
@@ -87,22 +87,43 @@ function renderComponentMinorVersions(componentId, minorVersions, props) {
 
 function renderComponentVersions(componentId, minorVersionId, versions, props) {
     const {showRc, currentArtifacts} = props
-    const {selectedComponent, selectedVersion} = currentArtifacts
-    return Object.values(versions).filter(version => {
+
+    const filteredVersions = Object.values(versions).filter(version => {
         return showRc || version.status !== 'RC'
-    }).map(version => {
-        const versionId = version.version
-        const displayName = versionId + (version.status === 'RELEASE' ? '' : `-${version.status}`)
-        return {
-            id: versionId,
-            label: displayName,
-            version: versionId,
-            minorVersion: minorVersionId,
-            componentId: componentId,
-            icon: 'build',
-            isSelected: selectedComponent === componentId && selectedVersion === versionId
+    }).map(version => renderComponentVersion(componentId, minorVersionId, version, currentArtifacts))
+
+    const regularVersions = filteredVersions.filter(version => !version.hotfix)
+    const hotfixVersions = filteredVersions.filter(version => version.hotfix)
+
+    hotfixVersions.forEach(hotfixVersion => {
+        const parentVersion = regularVersions.find(version => hotfixVersion.version.startsWith(version.version))
+        if (!parentVersion) return
+        if (!parentVersion.childNodes) {
+            parentVersion.childNodes = []
+            parentVersion.isExpanded = true
         }
+        parentVersion.childNodes.push(hotfixVersion)
     })
+
+    return regularVersions
+}
+
+function renderComponentVersion(componentId, minorVersionId, version, currentArtifacts) {
+    const {selectedComponent, selectedVersion} = currentArtifacts
+
+    const versionId = version.version
+    const displayName = versionId + (version.status === 'RELEASE' ? '' : `-${version.status}`)
+
+    return {
+        id: versionId,
+        label: displayName,
+        version: versionId,
+        minorVersion: minorVersionId,
+        componentId: componentId,
+        hotfix: version.hotfix,
+        icon: version.hotfix ? 'wrench' : 'build',
+        isSelected: selectedComponent === componentId && selectedVersion === versionId
+    }
 }
 
 export {

--- a/frontend/src/components/GroupedComponentsTree/presenter.jsx
+++ b/frontend/src/components/GroupedComponentsTree/presenter.jsx
@@ -125,7 +125,7 @@ function renderVersions(groupId, componentId, minorVersion, versions, props) {
             hotfixVersion.version.startsWith(version.version + '.')
         )
         if (!parentVersion) {
-            console.log(`Parent version not found for hotfix version ${hotfixVersion.version}`)
+            console.warn(`Parent version not found for hotfix version ${hotfixVersion.version}`)
             return
         }
         if (!parentVersion.childNodes) {

--- a/frontend/src/components/GroupedComponentsTree/presenter.jsx
+++ b/frontend/src/components/GroupedComponentsTree/presenter.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import {Spinner, Tree} from "@blueprintjs/core";
-import {getSecondaryLabel} from "../common";
+import { Spinner, Tree } from "@blueprintjs/core";
+import { getSecondaryLabel } from "../common";
+import { groupHotfixVersions } from "../../utils/version";
 
 const treeLevel = {
     GROUP: 'GROUP',
@@ -116,26 +117,7 @@ function renderVersions(groupId, componentId, minorVersion, versions, props) {
         return showRc || version.status !== 'RC'
     }).map(version => renderVersion(groupId, componentId, minorVersion, version, currentArtifacts))
 
-    const regularVersions = filteredVersions.filter(version => !version.hotfix)
-    const hotfixVersions = filteredVersions.filter(version => version.hotfix)
-
-    hotfixVersions.forEach(hotfixVersion => {
-        const parentVersion = regularVersions.find(version =>
-            hotfixVersion.version.startsWith(version.version + '-') ||
-            hotfixVersion.version.startsWith(version.version + '.')
-        )
-        if (!parentVersion) {
-            console.warn(`Parent version not found for hotfix version ${hotfixVersion.version}`)
-            return
-        }
-        if (!parentVersion.childNodes) {
-            parentVersion.childNodes = []
-            parentVersion.isExpanded = true
-        }
-        parentVersion.childNodes.push(hotfixVersion)
-    })
-
-    return regularVersions
+    return groupHotfixVersions(filteredVersions)
 }
 
 function renderVersion (groupId, componentId, minorVersion, version, currentArtifacts) {

--- a/frontend/src/components/GroupedComponentsTree/presenter.jsx
+++ b/frontend/src/components/GroupedComponentsTree/presenter.jsx
@@ -111,26 +111,45 @@ function renderComponentMinorVersions(groupId, componentId, minorVersions, props
 
 function renderVersions(groupId, componentId, minorVersion, versions, props) {
     const {showRc, currentArtifacts} = props
+
+    const filteredVersions = Object.values(versions).filter(version => {
+        return showRc || version.status !== 'RC'
+    }).map(version => renderVersion(groupId, componentId, minorVersion, version, currentArtifacts))
+
+    const regularVersions = filteredVersions.filter(version => !version.hotfix)
+    const hotfixVersions = filteredVersions.filter(version => version.hotfix)
+
+    hotfixVersions.forEach(hotfixVersion => {
+        const parentVersion = regularVersions.find(version => hotfixVersion.version.startsWith(version.version))
+        if (!parentVersion) return
+        if (!parentVersion.childNodes) {
+            parentVersion.childNodes = []
+            parentVersion.isExpanded = true
+        }
+        parentVersion.childNodes.push(hotfixVersion)
+    })
+
+    return regularVersions
+}
+
+function renderVersion (groupId, componentId, minorVersion, version, currentArtifacts) {
     const {selectedGroup, selectedComponent, selectedVersion} = currentArtifacts
-    return Object.values(versions)
-        .filter(version => {
-            return showRc || version.status !== 'RC'
-        })
-        .map(version => {
-            const displayName = version.version + (version.status === 'RELEASE' ? '' : `-${version.status}`)
-            return {
-                level: treeLevel.VERSION,
-                id: version.id,
-                label: displayName,
-                groupId: groupId,
-                componentId: componentId,
-                minorVersion: minorVersion,
-                version: version.version,
-                icon: 'build',
-                isSelected: selectedGroup === groupId && selectedComponent === componentId
-                    && selectedVersion === version.version
-            }
-        })
+
+    const displayName = version.version + (version.status === 'RELEASE' ? '' : `-${version.status}`)
+
+    return {
+        level: treeLevel.VERSION,
+        id: version.id,
+        label: displayName,
+        groupId: groupId,
+        componentId: componentId,
+        minorVersion: minorVersion,
+        version: version.version,
+        hotfix: version.hotfix,
+        icon: version.hotfix ? 'wrench' : 'build',
+        isSelected: selectedGroup === groupId && selectedComponent === componentId
+            && selectedVersion === version.version
+    }
 }
 
 export {

--- a/frontend/src/components/GroupedComponentsTree/presenter.jsx
+++ b/frontend/src/components/GroupedComponentsTree/presenter.jsx
@@ -120,8 +120,14 @@ function renderVersions(groupId, componentId, minorVersion, versions, props) {
     const hotfixVersions = filteredVersions.filter(version => version.hotfix)
 
     hotfixVersions.forEach(hotfixVersion => {
-        const parentVersion = regularVersions.find(version => hotfixVersion.version.startsWith(version.version))
-        if (!parentVersion) return
+        const parentVersion = regularVersions.find(version =>
+            hotfixVersion.version.startsWith(version.version + '-') ||
+            hotfixVersion.version.startsWith(version.version + '.')
+        )
+        if (!parentVersion) {
+            console.log(`Parent version not found for hotfix version ${hotfixVersion.version}`)
+            return
+        }
         if (!parentVersion.childNodes) {
             parentVersion.childNodes = []
             parentVersion.isExpanded = true

--- a/frontend/src/components/Meta/presenter.jsx
+++ b/frontend/src/components/Meta/presenter.jsx
@@ -10,14 +10,16 @@ export default function meta(props) {
                 <MetaItem icon='application' keyName='Component name' value={meta.componentName}/>
                 <MetaItem icon='id-number' keyName='Component ID' value={meta.componentId}/>
                 <MetaItem icon='box' keyName='Version' value={meta.version}/>
+            </div>
+            <div className="meta-column">
                 <MetaItem icon='wrench' keyName='Hotfix' value={meta.hotfix ? "yes" : "no"}/>
                 <MetaItem icon='applications' keyName='Solution' value={meta.solution ? "yes" : "no"}/>
+                <MetaItem icon='git-push' keyName='Published' value={meta.published ? "yes" : "no"}/>
             </div>
             <div className="meta-column">
                 <MetaItem icon='dollar' keyName='Client Code' value={!!meta.clientCode ? meta.clientCode : "none"}/>
                 <MetaItem icon='fork' keyName='Parent Component ID' value={!!meta.parentComponent ? meta.parentComponent : "none"}/>
                 <MetaItem icon='build' keyName='Status' value={meta.status}/>
-                <MetaItem icon='git-push' keyName='Published' value={meta.published ? "yes" : "no"}/>
             </div>
         </div>
     } else {

--- a/frontend/src/components/Meta/presenter.jsx
+++ b/frontend/src/components/Meta/presenter.jsx
@@ -10,6 +10,7 @@ export default function meta(props) {
                 <MetaItem icon='application' keyName='Component name' value={meta.componentName}/>
                 <MetaItem icon='id-number' keyName='Component ID' value={meta.componentId}/>
                 <MetaItem icon='box' keyName='Version' value={meta.version}/>
+                <MetaItem icon='wrench' keyName='Hotfix' value={meta.hotfix ? "yes" : "no"}/>
                 <MetaItem icon='applications' keyName='Solution' value={meta.solution ? "yes" : "no"}/>
             </div>
             <div className="meta-column">

--- a/frontend/src/components/SolutionTree/presenter.jsx
+++ b/frontend/src/components/SolutionTree/presenter.jsx
@@ -110,7 +110,7 @@ function renderVersions(solutionId, solutionMinor, solutionVersions, props) {
                 solutionId: solutionId,
                 solutionMinor: solutionMinor,
                 solutionVersion: solutionVersion,
-                icon: 'build',
+                icon: version.hotfix ? 'wrench' : 'build',
                 isExpanded: version.expand,
                 isSelected: selectedComponent === solutionId && selectedVersion === solutionVersion,
                 childNodes: childNodes,

--- a/frontend/src/components/SolutionTree/presenter.jsx
+++ b/frontend/src/components/SolutionTree/presenter.jsx
@@ -110,6 +110,7 @@ function renderVersions(solutionId, solutionMinor, solutionVersions, props) {
                 solutionId: solutionId,
                 solutionMinor: solutionMinor,
                 solutionVersion: solutionVersion,
+                hotfix: version.hotfix,
                 icon: version.hotfix ? 'wrench' : 'build',
                 isExpanded: version.expand,
                 isSelected: selectedComponent === solutionId && selectedVersion === solutionVersion,

--- a/frontend/src/components/duck/reducers.js
+++ b/frontend/src/components/duck/reducers.js
@@ -302,6 +302,7 @@ const componentsReducer = (state = INITIAL_STATE, action) => {
                         clientCode: componentVersion.clientCode,
                         parentComponent: componentVersion.parentComponent,
                         version: componentVersion.version,
+                        hotfix: componentVersion.hotfix,
                         status: componentVersion.status + " ("  + (!!componentVersion.promotedAt ? new Date(componentVersion.promotedAt).toLocaleString("ru-RU") : "unknown") + ")",
                         published: componentVersion.published
                     },

--- a/frontend/src/utils/version.js
+++ b/frontend/src/utils/version.js
@@ -1,0 +1,26 @@
+function isHotfixOf(hotfixVersion, parentVersion) {
+    return hotfixVersion.startsWith(parentVersion + '-') ||
+           hotfixVersion.startsWith(parentVersion + '.')
+}
+
+export function groupHotfixVersions(filteredVersions) {
+    const regularVersions = filteredVersions.filter(version => !version.hotfix)
+    const hotfixVersions = filteredVersions.filter(version => version.hotfix)
+
+    hotfixVersions.forEach(hotfixVersion => {
+        const parentVersion = regularVersions.find(version =>
+            isHotfixOf(hotfixVersion.version, version.version)
+        )
+        if (!parentVersion) {
+            console.warn(`Parent version not found for hotfix version ${hotfixVersion.version}`)
+            return
+        }
+        if (!parentVersion.childNodes) {
+            parentVersion.childNodes = []
+            parentVersion.isExpanded = true
+        }
+        parentVersion.childNodes.push(hotfixVersion)
+    })
+
+    return regularVersions
+}


### PR DESCRIPTION
### Differentiated hotfix versions across the **_All_**, **_Custom_**, and **_Clients_** views
Hotfix versions are now clearly distinguished visually, as shown below:

<img width="376" height="724" alt="image" src="https://github.com/user-attachments/assets/e2ef812b-761b-45b6-97fb-9ab1e3e486b2" />

### Hotfix versions for **_Solutions_**
Hotfix versions are differentiated only by their icon, keeping the existing visual layout consistent.

<img width="362" height="334" alt="image" src="https://github.com/user-attachments/assets/309bbe4d-d0bf-4c0e-8a5f-4c2b73992a06" />

### Added hotfix indicators to the **_Component Version Artifacts_** section

**Before:**

<img width="656" height="92" alt="image" src="https://github.com/user-attachments/assets/436c3b60-a375-44d1-8b5e-5578215241a3" />

**After:**

<img width="1582" height="144" alt="image" src="https://github.com/user-attachments/assets/d9e081fc-a565-45b5-bbbe-394764b8ba3f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hotfix versions are grouped under their corresponding regular versions and auto-expanded for easier navigation.
  * Version metadata now shows Hotfix and Published statuses in the meta view.
  * Visual indicators: wrench icon for hotfixes, build icon for regular versions.

* **Refactor**
  * Version rendering logic streamlined for clearer selection state and stability; orphan hotfixes are detected and skipped (with a logged warning).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->