### PR TITLE
Change artifactory version to v7.125.11

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   artifactory:
-    image: releases-docker.jfrog.io/jfrog/artifactory-oss:7.125.7
+    image: releases-docker.jfrog.io/jfrog/artifactory-oss:7.125.11
     container_name: artifactory
     depends_on:
       postgres:


### PR DESCRIPTION
### Description
This PR upgrades JFrog Artifactory from v7.125.7 to v7.125.11.

### Reason
- The previous version (7.125.7) showed stability issues.
- Version 7.125.11 includes bug fixes and stability improvements, making it more reliable for our current setup.

### Changes
- Updated Artifactory version from 7.125.7 → 7.125.11
- No configuration changes
- No breaking changes expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifactory service image to version 7.125.11. All other service configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->